### PR TITLE
Fix comment level handling in find-local-source.py

### DIFF
--- a/diffscuss/walker.py
+++ b/diffscuss/walker.py
@@ -72,9 +72,15 @@ def walk(fil):
             # level can increase by more than one....
             if line_level - cur_comment_level > 1:
                 raise BadNestingException()
+
             # or if we've changed level mid-comment...
-            if line_level != cur_comment_level and not _is_author_line(line):
+            if (line_level != cur_comment_level
+                #and not _is_author_line(line)
+                and not _is_header(line)):
                 raise BadNestingException()
+
+            # At this point, we accept the new line_level
+            cur_comment_level = line_level
 
             # or if this is a header line of a comment and it's not
             # either following a header or is an author line or an empty line...


### PR DESCRIPTION
It was consistently failing for me, due to (once I ran the python from the command line and made it chattier), a combo of two line-level problems:

 1) It was failing to recognize a change in comment level due to a reply starting, because it was throwing a BadNestingException() due to a comment-line-level mismatch on a non-author line. 

But I think it's valid (or at least, my C-c c was creating) to have a blank header line before the author, no?  

I'm doing this as a pull req partly because I'm not clear on the logic, so wanted to push it up for discussion.

I did _not_ make the logic narrowly reflect what I wrote above - I hit it with the bigger stick of just accepting any header line.  It would be not that hard to do either blank header or author, but it could then get tricky to figure out where to update current_comment_level.

 2) It was also never updating current_comment_level, so even after I fixed the above, it would die as soon as it got to a non-header line (or some such).

If I wasn't rushing, would sooooo write the tests.  But, oh, well.
